### PR TITLE
Use project name as context root

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -3,7 +3,8 @@ lazy val root = (project in file(".")).
   settings(
     name := "$name;format="normalized"$",
     scalaVersion := "2.11.8",
-    webappWebInfClasses := true
+    webappWebInfClasses := true,
+    containerArgs := Seq("--path", "/$name;format="normalized"$")
   )
 enablePlugins(JettyPlugin)
 


### PR DESCRIPTION
This change will use the project name as the context root, but only when running Jetty through SBT.

I recall we talked about renaming the WAR file to remove the version information included by default. I don't know if that's something we want to do here or what the implications of doing that are.